### PR TITLE
added 'async' to FunctionDeclaration primitives

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@
         alias: 'func-dec',
         nodes: ['id', 'body'],
         nodeArrays: ['params'],
-        primitives: ['generator'],
+        primitives: ['generator', 'async'],
         syntax: 'function *id*([*param_1*], [*param_2*], [..., *param_3*])\n  *body*',
         example: 'function f(x, y) {\n  return x * y;\n}',
         note: 'A function declaration contrasts with a function expression (func-exp).'

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@
         alias: 'func-exp',
         nodes: ['id', 'body'],
         nodeArrays: ['params'],
-        primitives: ['generator'],
+        primitives: ['generator', 'async'],
         syntax: 'function [*id*]([*param_1*], [*param_2*], [..., *param_3*])\n  *body*',
         example: 'let f = function(x, y) {\n  return x * y;\n}',
         note: 'A function expression contrasts with a function declaration (func-dec).'
@@ -229,7 +229,7 @@
         alias: 'arrow',
         nodes: ['id', 'body'],
         nodeArrays: ['params'],
-        primitives: ['generator', 'expression'],
+        primitives: ['generator', 'expression', 'async'],
         syntax: '([*param_1*], [*param_2*], [..., *param_3*]) => *body*',
         example: '(x, y) => x * y'
       },

--- a/index.ls
+++ b/index.ls
@@ -314,7 +314,7 @@ syntax =
       alias: 'func-exp'
       nodes: <[ id body ]>
       node-arrays: <[ params ]>
-      primitives: <[ generator ]>
+      primitives: <[ generator async ]>
       syntax: '''
               function [*id*]([*param_1*], [*param_2*], [..., *param_3*])
                 *body*
@@ -329,7 +329,7 @@ syntax =
       alias: 'arrow'
       nodes: <[ id body ]>
       node-arrays: <[ params ]>
-      primitives: <[ generator expression ]>
+      primitives: <[ generator expression async ]>
       syntax: '''
               ([*param_1*], [*param_2*], [..., *param_3*]) => *body*
               '''

--- a/index.ls
+++ b/index.ls
@@ -259,7 +259,7 @@ syntax =
       alias: 'func-dec'
       nodes: <[ id body ]>
       node-arrays: <[ params ]>
-      primitives: <[ generator ]>
+      primitives: <[ generator async ]>
       syntax: '''
               function *id*([*param_1*], [*param_2*], [..., *param_3*])
                 *body*


### PR DESCRIPTION
Allow queries ike this:
```
$ grasp -s 'FunctionDeclaration[async=true]'  /some/path
1-3:(multiline):
async function x(){
        console.log(1);
}
```
